### PR TITLE
do not run pr action on `main` 🪓

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,0 +1,15 @@
+name: build
+on: # rebuild any PRs and main branch changes
+  workflow_dispatch: ~
+  pull_request: ~
+  push:
+    branches:
+      - main
+
+jobs:
+  build: # make sure build/ci work properly
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - run: npm install
+      - run: npm run all

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,18 +1,8 @@
-name: 'build-test'
-on: # rebuild any PRs and main branch changes
-  workflow_dispatch: ~
+name: test run
+on: # run on any PRs
   pull_request: ~
-  push:
-    branches:
-      - main
 
 jobs:
-  build: # make sure build/ci work properly
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v3
-      - run: npm install
-      - run: npm run all
   run:
     runs-on: ubuntu-latest
     steps:


### PR DESCRIPTION
Split the `build-test` action so that `build` continues to run on pushes
to `main` but `test` runs only on PRs (because the action requires PR
context to function properly).
